### PR TITLE
Allow hyphens in LDAP names

### DIFF
--- a/index.php
+++ b/index.php
@@ -61,7 +61,7 @@ foreach ( $ldapGroups as $group ) {
 		'wmf-ldap-' . $group,
 		'https://tools.wmflabs.org/ldap/group/' . $group
 	);
-	preg_match_all( '/"\/ldap\/user\/([a-zA-Z0-9]*)"\>/', $html, $userMatches );
+	preg_match_all( '/"\/ldap\/user\/([a-zA-Z0-9-]*)"\>/', $html, $userMatches );
 	$groupMap[$group] = $userMatches[1];
 }
 


### PR DESCRIPTION
Some LDAP usernames, e. g. `andrew-wmde`, `lucaswerkmeister-wmde`, `wmde-fisch`, contain hyphens.