### PR TITLE
Add integration project

### DIFF
--- a/index.php
+++ b/index.php
@@ -42,6 +42,7 @@ $groupsToCheck = [
 	MG_LDAP_CLOUD => [
 		// 'project-bastion', // Not working...
 		'project-deployment-prep',
+		'project-integration',
 		// 'project-tools', // Not working....
 		'project-wikidata-dev',
 		'project-wikidata-query',


### PR DESCRIPTION
Since 2024-07-29, some developers are members of this project, which allows us to delete broken castor caches that are blocking CI ourselves if needed.

Bug: [T370766](https://phabricator.wikimedia.org/T370766)